### PR TITLE
Feature interface prefill

### DIFF
--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -36,6 +36,9 @@ export default class Interface {
         
         interfaceAlignment.value = alignment;
         
+        interfaceHideChannel.checked = channelHidden;
+        
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -31,6 +31,10 @@ export default class Interface {
         
         interfaceServer.value = serverSelectMode;
         
+        if(serverSelectMode === "by_name") {
+            interfaceServerName.value = serverSelectModeOptions.name;
+        }
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -25,6 +25,8 @@ export default class Interface {
             interfaceCustomAppId.disabled = false;
         }
         
+        interfaceAppPort.value = `${appPort}`;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -43,6 +43,8 @@ export default class Interface {
         
         interfaceOnlyTalking.checked = silentClientsHidden;
         
+        interfaceShowAvatars.checked = avatarsShown;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -12,12 +12,20 @@ export default class Interface {
      * 
      * @param {Handler} handler
      * @param {Viewer} viewer 
-     * @param {{customId: string, appPort: number, mode: import("../viewer/Viewer.js").ViewerMode, serverSelectMode: import("../viewer/Viewer.js").ServerSelectMode, serverSelectModeOptions: *, scale: number, alignment: string, localClientColorEnabled: boolean, channelHidden: boolean, silentClientsHidden: boolean, statusHidden: boolean, avatarsShown: boolean, spacersShown: boolean, emptyChannelsHidden: boolean, queryClientsShown: boolean}} prefillOptions 
+     * @param {{customId: string | undefined, appPort: number, mode: import("../viewer/Viewer.js").ViewerMode, serverSelectMode: import("../viewer/Viewer.js").ServerSelectMode, serverSelectModeOptions: *, scale: number, alignment: string, localClientColorEnabled: boolean, channelHidden: boolean, silentClientsHidden: boolean, statusHidden: boolean, avatarsShown: boolean, spacersShown: boolean, emptyChannelsHidden: boolean, queryClientsShown: boolean}} prefillOptions 
      */
     constructor(handler, viewer, {customId, appPort, mode, serverSelectMode, serverSelectModeOptions, scale, alignment, localClientColorEnabled, channelHidden, silentClientsHidden, statusHidden, avatarsShown, spacersShown, emptyChannelsHidden, queryClientsShown}) {
         this.#handler = handler;
         this.#viewer = viewer;
         
+        //Prefilled Values
+        if(customId) {
+            interfaceUseCustomId.checked = true;
+            interfaceCustomAppId.value = customId;
+            interfaceCustomAppId.disabled = false;
+        }
+        
+        //Init
         this.#init();
     }
     

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -27,6 +27,8 @@ export default class Interface {
         
         interfaceAppPort.value = `${appPort}`;
         
+        interfaceViewerMode.value = mode;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -49,6 +49,8 @@ export default class Interface {
         
         interfaceShowSpacers.checked = spacersShown;
         
+        interfaceDisableLocalClientColor.checked = !localClientColorEnabled;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -51,6 +51,8 @@ export default class Interface {
         
         interfaceDisableLocalClientColor.checked = !localClientColorEnabled;
         
+        interfaceShowQueryClients.checked = queryClientsShown;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -41,6 +41,8 @@ export default class Interface {
         
         interfaceHideStatus.checked = statusHidden;
         
+        interfaceOnlyTalking.checked = silentClientsHidden;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -53,6 +53,9 @@ export default class Interface {
         
         interfaceShowQueryClients.checked = queryClientsShown;
         
+        interfaceScaleSlider.value = `${Math.max(0, Math.min(4, scale))}`;
+        interfaceScale.value = `${scale}`;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -40,17 +40,11 @@ export default class Interface {
         interfaceHideChannel.disabled = mode !== "channel";
         
         interfaceHideStatus.checked = statusHidden;
-        
         interfaceOnlyTalking.checked = silentClientsHidden;
-        
         interfaceShowAvatars.checked = avatarsShown;
-        
         interfaceHideEmpty.checked = emptyChannelsHidden;
-        
         interfaceShowSpacers.checked = spacersShown;
-        
         interfaceDisableLocalClientColor.checked = !localClientColorEnabled;
-        
         interfaceShowQueryClients.checked = queryClientsShown;
         
         interfaceScaleSlider.value = `${Math.max(0, Math.min(4, scale))}`;

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -45,6 +45,8 @@ export default class Interface {
         
         interfaceShowAvatars.checked = avatarsShown;
         
+        interfaceHideEmpty.checked = emptyChannelsHidden;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -30,10 +30,11 @@ export default class Interface {
         interfaceViewerMode.value = mode;
         
         interfaceServer.value = serverSelectMode;
-        
         if(serverSelectMode === "by_name") {
             interfaceServerName.value = serverSelectModeOptions.name;
         }
+        
+        interfaceAlignment.value = alignment;
         
         //Init
         this.#init();

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -12,8 +12,9 @@ export default class Interface {
      * 
      * @param {Handler} handler
      * @param {Viewer} viewer 
+     * @param {{customId: string, appPort: number, mode: import("../viewer/Viewer.js").ViewerMode, serverSelectMode: import("../viewer/Viewer.js").ServerSelectMode, serverSelectModeOptions: *, scale: number, alignment: string, localClientColorEnabled: boolean, channelHidden: boolean, silentClientsHidden: boolean, statusHidden: boolean, avatarsShown: boolean, spacersShown: boolean, emptyChannelsHidden: boolean, queryClientsShown: boolean}} prefillOptions 
      */
-    constructor(handler, viewer) {
+    constructor(handler, viewer, {customId, appPort, mode, serverSelectMode, serverSelectModeOptions, scale, alignment, localClientColorEnabled, channelHidden, silentClientsHidden, statusHidden, avatarsShown, spacersShown, emptyChannelsHidden, queryClientsShown}) {
         this.#handler = handler;
         this.#viewer = viewer;
         

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -39,6 +39,8 @@ export default class Interface {
         interfaceHideChannel.checked = channelHidden;
         interfaceHideChannel.disabled = mode !== "channel";
         
+        interfaceHideStatus.checked = statusHidden;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -47,6 +47,8 @@ export default class Interface {
         
         interfaceHideEmpty.checked = emptyChannelsHidden;
         
+        interfaceShowSpacers.checked = spacersShown;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -29,6 +29,8 @@ export default class Interface {
         
         interfaceViewerMode.value = mode;
         
+        interfaceServer.value = serverSelectMode;
+        
         //Init
         this.#init();
     }

--- a/js/interface/Interface.js
+++ b/js/interface/Interface.js
@@ -37,7 +37,7 @@ export default class Interface {
         interfaceAlignment.value = alignment;
         
         interfaceHideChannel.checked = channelHidden;
-        
+        interfaceHideChannel.disabled = mode !== "channel";
         
         //Init
         this.#init();

--- a/js/main.js
+++ b/js/main.js
@@ -77,7 +77,7 @@ async function main() {
     
     if(app.isInterfaceShown()) {
         const ui = new Interface(handler, viewer, {
-            customId: getOrDefault(getParam("custom_id"), ""),
+            customId: getParam("custom_id"),
             appPort: apiPort,
             ...viewerOptions
         });

--- a/js/main.js
+++ b/js/main.js
@@ -55,7 +55,7 @@ async function main() {
     const hideEmptyChannels = getParamBoolean("hide_empty");
     const showQueryClients = getParamBoolean("show_query_clients");
     
-    const viewer = new Viewer(handler, {
+    const viewerOptions = {
         mode: viewerMode,
         serverSelectMode: serverSelectMode,
         serverSelectModeOptions: serverSelectModeOptions,
@@ -69,12 +69,18 @@ async function main() {
         spacersShown: showSpacers,
         emptyChannelsHidden: hideEmptyChannels,
         queryClientsShown: showQueryClients,
-    });
+    };
+    
+    const viewer = new Viewer(handler, viewerOptions);
     
     viewer.updateSelectedServer();
     
     if(app.isInterfaceShown()) {
-        const ui = new Interface(handler, viewer);
+        const ui = new Interface(handler, viewer, {
+            customId: getOrDefault(getParam("custom_id"), ""),
+            appPort: apiPort,
+            ...viewerOptions
+        });
         
         ui.show();
         


### PR DESCRIPTION
This prefills the Customization Interface with the url parameters that are set (and actually used in the Viewer), which caused the Settings not to reflect the preview in those cases.